### PR TITLE
Add filtering for PKGNAME

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '5.0.0'
 
 }
-version = '0.2'
+version = '0.3'
 mainClassName = "muddler.App"
 
 repositories {
@@ -24,8 +24,6 @@ repositories {
     // You can declare any Maven/Ivy/file repository here.
     jcenter()
 }
-version = '0.2-SNAPSHOT'
-mainClassName = "muddler.App"
 
 //jar {
 //    manifest {

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>muddler</groupId>
   <artifactId>muddler</artifactId>
-  <version>0.2-SNAPSHOT</version>
+  <version>0.3</version>
   <inceptionYear>2019</inceptionYear>
   <dependencies>
     <dependency>

--- a/src/main/groovy/muddler/mudlet/items/Item.groovy
+++ b/src/main/groovy/muddler/mudlet/items/Item.groovy
@@ -33,7 +33,7 @@ abstract class Item {
 
   def readScripts(String itemType) {
     if (this.script == "" && this.isFolder != "yes" ) {
-      def fullPath = "src${File.separator}$itemType${File.separator}${this.path}${File.separator}${this.name.replaceAll(" ", "_")}.lua"
+      def fullPath = "build/filtered/src${File.separator}$itemType${File.separator}${this.path}${File.separator}${this.name.replaceAll(" ", "_")}.lua"
       def scriptFile = new File(fullPath)
       if (scriptFile.exists()) {
         this.script = scriptFile.text.normalize()

--- a/src/main/groovy/muddler/mudlet/packages/Package.groovy
+++ b/src/main/groovy/muddler/mudlet/packages/Package.groovy
@@ -13,7 +13,7 @@ abstract class Package {
   abstract def newItem(Map options)
 
   def Package(String packageType ) {
-    this.baseDir = new File("src/$packageType")
+    this.baseDir = new File("build/filtered/src/$packageType")
     this.children = []
     if (baseDir.exists()) {
       this.files = this.findFiles()
@@ -38,7 +38,8 @@ abstract class Package {
     def fullItemsAsArrays = []
     this.files.each {
       def fileArray = "${it}".split(Pattern.quote(File.separator)).toList()
-      def directoriesInPath = fileArray[2..-2]
+      // 4..-2 as we don't want to include build/filtered/src/$type
+      def directoriesInPath = fileArray[4..-2]
       def filePath = directoriesInPath.join(File.separator)
       def itemPayload = []
       def itemArray = []


### PR DESCRIPTION
Use groovy's built in AntBuilder which we are alread leveraging to filter source files and replace @PKGNAME@ with the packagename-version which is used to identify the package and filenames by muddler.

This allows you to use getMudletHomeDir() .. "@PKGNAME@/" to get the directory your package will drop its files into, as if the packagename-version is anitimers-3.0 the above would become getMudletHomeDir() .. "anitimers-3.0/" 

Also, mark 0.3 for muddler