### PR TITLE
Allows for Items which exist in the root of a Package folder rather than in a subfolder to be included as direct children of the Package's entity, rather than contained in an ItemGroup

### DIFF
--- a/src/main/groovy/muddler/mudlet/packages/Package.groovy
+++ b/src/main/groovy/muddler/mudlet/packages/Package.groovy
@@ -7,6 +7,7 @@ import muddler.Echo
 
 
 abstract class Package {
+  String basePath
   File baseDir
   List files
   List children
@@ -17,7 +18,8 @@ abstract class Package {
   def Package(String packageType ) {
     this.e = new Echo()
     e.echo("Scanning for $packageType")
-    this.baseDir = new File("build/filtered/src/$packageType")
+    this.basePath = "build/filtered/src/$packageType"
+    this.baseDir = new File(this.basePath)
     this.children = []
     if (baseDir.exists()) {
       this.files = this.findFiles()
@@ -41,31 +43,42 @@ abstract class Package {
   def createItems() {
     def fullItemsAsArrays = []
     this.files.each {
-      def fileArray = "${it}".split(Pattern.quote(File.separator)).toList()
-      // 4..-2 as we don't want to include build/filtered/src/$type
-      def directoriesInPath = fileArray[4..-2]
-      def filePath = directoriesInPath.join(File.separator)
-      def relativePath = fileArray[2..-1].join(File.separator)
+      // We don't want to include build/filtered/src/ in the path, so remove
+      // the basePath prefix from each filename
+      def quotedBasePath = Pattern.quote(this.basePath)
+      def relativeToBase = "${it}".replaceFirst("^${quotedBasePath}/", "")
+      def relativePath = relativeToBase.split(Pattern.quote(File.separator)).toList()
+
+      def directoriesInPath = relativePath[0..<-1]
+      def filePath =  directoriesInPath.join(File.separator)
+      def fileName = relativePath.join(File.separator)
+
       def itemPayload = []
       def itemArray = []
       def jsonItems
       try {
         jsonItems = new JsonSlurper().parse(it)
       } catch (groovy.json.JsonException ex) {
-        e.error("There was an error reading the json file ./$relativePath:", ex)
+        e.error("There was an error reading the json file ./$fileName:", ex)
       }
       jsonItems.each {
         it.path = filePath
         itemPayload.add(newItem(it))
       }
-      directoriesInPath.each {
-        def properties = [:]
-        properties.isFolder = "yes"
-        properties.name = it
-        itemArray.add(newItem(properties))
+
+      if (directoriesInPath.isEmpty()) {
+        this.children.addAll(itemPayload)
+      } else {
+        directoriesInPath.each {
+          def properties = [:]
+          properties.isFolder = "yes"
+          properties.name = it
+          itemArray.add(newItem(properties))
+        }
+
+        itemArray.add(itemPayload)
+        fullItemsAsArrays.add(itemArray)
       }
-      itemArray.add(itemPayload)
-      fullItemsAsArrays.add(itemArray)
     }
     fullItemsAsArrays.each {
       def testData = it

--- a/src/main/groovy/muddler/mudlet/packages/Package.groovy
+++ b/src/main/groovy/muddler/mudlet/packages/Package.groovy
@@ -45,8 +45,8 @@ abstract class Package {
     this.files.each {
       // We don't want to include build/filtered/src/ in the path, so remove
       // the basePath prefix from each filename
-      def quotedBasePath = Pattern.quote(this.basePath)
-      def relativeToBase = "${it}".replaceFirst("^${quotedBasePath}/", "")
+      def quotedBasePath = Pattern.quote("${this.basePath}${File.separator}")
+      def relativeToBase = "${it}".replaceFirst("^${quotedBasePath}" , "")
       def relativePath = relativeToBase.split(Pattern.quote(File.separator)).toList()
 
       def directoriesInPath = relativePath[0..<-1]


### PR DESCRIPTION
Because Package.groovy always considers the last two sections of a package's json manifest's filename, it doesn't work well for any packages which live outside of nested subfolders.

For example, given this muddler project layout:

```
src
src/aliases
src/keys
src/resources
src/scripts
src/timers
src/triggers
src/triggers/Bar.lua
src/triggers/Foo.lua
src/triggers/FooBar
src/triggers/FooBar/Beep.lua
src/triggers/FooBar/triggers.json
src/triggers/triggers.json
```

The structure of the generated package looks like this:
<img width="154" alt="image" src="https://user-images.githubusercontent.com/978231/194693471-3ad37ab4-4d81-485e-8cf5-1e858f882391.png">

This PR attempts to offer some basic support for a package manifest and scripts to exist the base of each package type's respective root folder, allowing for muddler packages to look like this:

<img width="144" alt="image" src="https://user-images.githubusercontent.com/978231/194693639-56c2e1d3-59cc-4e46-9a0e-719f4e788125.png">

It has only been tested on Mac OS, but I'd expect it to work fine on other platforms.
