### PR TITLE
Code in folders/groups

### DIFF
--- a/src/main/groovy/muddler/App.groovy
+++ b/src/main/groovy/muddler/App.groovy
@@ -122,7 +122,7 @@ class App {
     tmp.mkdirs()
     // filter our source files from src into build/filtered/src and replace @PKGNAME@ with the package name as used by Mudlet
     // no more images failing to load because the package name changed or you bumped version
-    e.echo("Filtering @PKGNAME@ to '$packageName' and @VERSION@ to '$packageVersion'")
+    e.echo("Filtering @PKGNAME@ and __PKGNAME__ to '$packageName' and @VERSION@ and __VERSION__ to '$packageVersion'")
     ant.copy(todir:'build/filtered/src') {
       fileset(dir: "src/") {
         exclude(name: "resources/")

--- a/src/main/groovy/muddler/mudlet/items/Item.groovy
+++ b/src/main/groovy/muddler/mudlet/items/Item.groovy
@@ -35,7 +35,7 @@ abstract class Item {
   }  
 
   def readScripts(String itemType) {
-    if (this.script == "" && this.isFolder != "yes" ) {
+    if (this.script == "") {
       def fullPath = "build/filtered/src${File.separator}$itemType${File.separator}${this.path}${File.separator}${this.name.replaceAll(" ", "_")}.lua"
       def scriptFile = new File(fullPath)
       if (scriptFile.exists()) {

--- a/src/main/groovy/muddler/mudlet/packages/Package.groovy
+++ b/src/main/groovy/muddler/mudlet/packages/Package.groovy
@@ -73,6 +73,7 @@ abstract class Package {
           def properties = [:]
           properties.isFolder = "yes"
           properties.name = it
+          properties.path = filePath
           itemArray.add(newItem(properties))
         }
 
@@ -116,7 +117,7 @@ abstract class Package {
       if (mergedList.size() == 0 ) {
         return mergeInto
       } else {
-        return mergeDown(mergedList, mergeInto)            
+        return mergeDown(mergedList, mergeInto)
       }
     }
   }


### PR DESCRIPTION
This change allows you to include Lua code in the folders of your project tree. Which is to say, if you want to include some Lua in the script folder "Startup" your file tree would include

```
src/scripts/Startup/scripts.json
scr/scripts/Startup/Startup.lua
```

And the script folder `Startup` from the mpackage will contain the contents of `Startup.lua`. This is done automatically, without having to add anything to the json. 

Resolves #13 