### PR TITLE
add watch option to automatically rebuild on source file modification

### DIFF
--- a/src/main/groovy/muddler/App.groovy
+++ b/src/main/groovy/muddler/App.groovy
@@ -25,6 +25,7 @@ class App {
       v longOpt: 'version', 'Print version information and exit'
       g longOpt: 'generate', 'Create a new muddler project by answering some questions.'
       d longOpt: 'default', 'Create a new default muddler template project named MyProject in the MyProject directory'
+      w longOpt: 'watch', 'Watch the src directory for changes and rebuild the package when they occur'
     }
     def options = cli.parse(args)
     if (!options) {
@@ -54,6 +55,18 @@ class App {
       return
     }
 
+    build()
+
+    if (options.w) {
+      watch()
+      return
+    }
+
+    System.exit(0)
+  }
+
+  static void build() {
+    def e = new Echo()
     def srcDir = new File('./src')
     if (!srcDir.exists()) {
       println "muddler requires a src directory to read your package contents from, and cannot find it. Please see https://github.com/demonnic/muddler#usage for more information on the file layout for muddler."
@@ -233,6 +246,38 @@ class App {
       }
     }
     e.echo("Build completed successfully!")
-    System.exit(0)
+  }
+
+  static Map<String, Long> mapFileModificationTimes(File directory) {
+    def fileModificationTimes = [:]
+    directory.eachFileRecurse { file ->
+      if (file.isFile()) {
+        fileModificationTimes[file.path] = file.lastModified()
+      }
+    }
+    return fileModificationTimes
+  }
+
+  static void watch() {
+    def e = new Echo()
+    def srcDir = new File('./src')
+    if (!srcDir.exists()) {
+      println 'muddler requires a src directory to read your package contents from, and cannot find it. Please see'
+      return
+    }
+
+    def previousFileModificationTimes = mapFileModificationTimes(srcDir)
+
+    while (true) {
+      Thread.sleep(1000)
+
+      def currentFileModificationTimes = mapFileModificationTimes(srcDir)
+
+      if (currentFileModificationTimes != previousFileModificationTimes) {
+        e.echo('Change detected in source directory')
+        build()
+        previousFileModificationTimes = currentFileModificationTimes
+      }
+    }
   }
 }


### PR DESCRIPTION
pretty much what it says on the tin. It's pretty rudimentary since the majority of the _nicer_ file modification mechanisms aren't implemented in the filesystem layer that Microsoft uses for WSL2 and, hence, don't trigger for docker under Windows. When a file changes in the `src` directory, it just runs the build process when it picks up the changed modification time on a regular 1 second interval. I've run the java jar and docker test image against the test packages without incident on Windows and in WSL.

I'm _not_ a groovy dev and was assisted by an LLM. I've scoured the docs for the code used and everything seems alright, but I'm not up on idiomatic Groovy by any means and am more than open to feedback.