### PR TITLE
adding support for callbacks

### DIFF
--- a/mpackage/src/scripts/muddler/code.lua
+++ b/mpackage/src/scripts/muddler/code.lua
@@ -44,7 +44,7 @@ function Muddler:stop()
   removeFileWatch(self.path .. "/.output")
 end
 
-local function execute(item,name)
+local function execute(item, name)
   if not item then
     debugc("Attempted to execute nil or false, must be string or function")
   end
@@ -87,20 +87,20 @@ function Muddler:reload()
   debugc("preremove " .. name)
   if prer then
     debugc(f"  Firing preremove for pkg: {name}")
-    execute(prer,name)
+    execute(prer, name)
     debugc(f"  END preremove for pkg: {name}")
   end
   uninstallPackage(name)
   debugc("postremove " .. name)
   if postr then
     debugc(f"  Firing postremove for pkg: {name}")
-    execute(postr,name)
+    execute(postr, name)
     debugc(f"  END postremove for pkg: {name}")
   end
   debugc("preinstall " .. name)
   if prei then
     debugc(f"  Firing preinstall for pkg: {name}")
-    execute(prei,name)
+    execute(prei, name)
     debugc(f"  END preinstall for pkg: {name}")
   end
   local succ = installPackage(path)
@@ -111,7 +111,7 @@ function Muddler:reload()
   debugc("postinstall " .. name)
   if posti then
     debugc(f"  Firing postinstall for pkg: {name}")
-    execute(posti,name)
+    execute(posti, name)
     debugc(f"  END postinstall for pkg: {name}")
   end
   debugc("Done reloading pkg " .. name)

--- a/mpackage/src/scripts/muddler/code.lua
+++ b/mpackage/src/scripts/muddler/code.lua
@@ -44,7 +44,7 @@ function Muddler:stop()
   removeFileWatch(self.path .. "/.output")
 end
 
-local function execute(item)
+local function execute(item,name)
   if not item then
     debugc("Attempted to execute nil or false, must be string or function")
   end
@@ -65,7 +65,7 @@ local function execute(item)
     debugc("Unable to execute item, need a function, got a " .. itype)
     return
   end
-  local worked, err = pcall(item)
+  local worked, err = pcall(item,name)
   if not worked then
     debugc("Error executing item: " .. tostring(err))
   end
@@ -87,20 +87,20 @@ function Muddler:reload()
   debugc("preremove " .. name)
   if prer then
     debugc(f"  Firing preremove for pkg: {name}")
-    execute(prer)
-    debugc(f"  END premove for pkg: {name}")
+    execute(prer,name)
+    debugc(f"  END preremove for pkg: {name}")
   end
   uninstallPackage(name)
   debugc("postremove " .. name)
   if postr then
     debugc(f"  Firing postremove for pkg: {name}")
-    execute(postr)
-    debugc(f"  END postmove for pkg: {name}")
+    execute(postr,name)
+    debugc(f"  END postremove for pkg: {name}")
   end
   debugc("preinstall " .. name)
   if prei then
     debugc(f"  Firing preinstall for pkg: {name}")
-    execute(prei)
+    execute(prei,name)
     debugc(f"  END preinstall for pkg: {name}")
   end
   local succ = installPackage(path)
@@ -111,7 +111,7 @@ function Muddler:reload()
   debugc("postinstall " .. name)
   if posti then
     debugc(f"  Firing postinstall for pkg: {name}")
-    execute(posti)
+    execute(posti,name)
     debugc(f"  END postinstall for pkg: {name}")
   end
   debugc("Done reloading pkg " .. name)


### PR DESCRIPTION
* corrected typos in debugc for `END premove for pkg` => `END preremove for pkg` and `END postmove` => `END postremove`
* added support for passing the package name to the callback functions. This enables having a single function for callbacks and making decisions on what to do based on the package name.